### PR TITLE
Adding bin-by-bin fit, bug fixes for datacards, samples, selections

### DIFF
--- a/DM/Analysis/datacard.py
+++ b/DM/Analysis/datacard.py
@@ -14,6 +14,7 @@ parser.add_option("-r", "--remove", action="store", type="string", default="", d
 parser.add_option("-c", "--cutcount", action="store_true", default=False, dest="isCutAndCount")
 parser.add_option("-o", "--override", action="store_true", default=False, dest="override")
 parser.add_option("-v", "--verbose", action="store_true", default=False, dest="verbose")
+parser.add_option("-N", "--name", action="store", type="string", dest="name", default="test")
 (options, args) = parser.parse_args()
 
 fileName = options.fileName
@@ -107,7 +108,7 @@ def datacard(cat, sign):
     card += "bin        " + space + ("%-25s" % cat) + "\n"
     card += "observation" + space + ("%-25.0f" % -1.) + "\n"
     card += hline
-    card += "shapes * * " + space + "rootfiles/$CHANNEL.root          $PROCESS          $SYSTEMATIC/$PROCESS\n"
+    card += "shapes * * " + space + "rootfiles_"+options.name+"/$CHANNEL.root          $PROCESS          $SYSTEMATIC/$PROCESS\n"
     card += hline
     card += "bin        " + space
     for i, s in enumerate([sign] + back):
@@ -202,11 +203,10 @@ def datacard(cat, sign):
     #inFile.Close()
     
     # Write to file
-    if not os.path.exists("datacards/"):
-        print "Error: directory", "datacards/ does not exist, aborting..."
-        exit()
+    try: os.stat("datacards_"+options.name) 
+    except: os.mkdir("datacards_"+options.name)
     
-    outname = "datacards/" + sign + '_' + cat + ".txt"
+    outname = "datacards_"+options.name+"/" + sign + '_' + cat + ".txt"
     cardfile = open(outname, 'w')
     cardfile.write(card)
     cardfile.close()
@@ -218,7 +218,7 @@ def datacard(cat, sign):
 
 
 def getNumber(cat, s, syst=''):
-    f = TFile("rootfiles/"+cat+".root", "READ")
+    f = TFile("rootfiles_"+options.name+"/"+cat+".root", "READ")
     h = f.Get((syst+'/' if len(syst)>0 else '')+s)
     if h==None: return -1
     n = h.Integral()
@@ -227,7 +227,7 @@ def getNumber(cat, s, syst=''):
     return n
 
 def checkShape(cat, s, syst=''):
-    f = TFile("rootfiles/"+cat+".root", "READ")
+    f = TFile("rootfiles_"+options.name+"/"+cat+".root", "READ")
     h = f.Get(s)
     hUp = f.Get(syst+'Up'+'/'+s)
     hDown = f.Get(syst+'Down'+'/'+s)
@@ -245,18 +245,22 @@ def checkShape(cat, s, syst=''):
 
 def fillLists():
     # List files and fill categories
-    for c in os.listdir('rootfiles/'):
+    for c in os.listdir('rootfiles_'+options.name+'/'):
         if c.endswith('root'):
             categories.append(c.replace('.root', ''))
     
     # Read file and histograms
-    inFile = TFile("rootfiles/"+categories[0]+".root", "READ")
+    inFile = TFile("rootfiles_"+options.name+"/"+categories[0]+".root", "READ")
     inFile.cd()
     for key in inFile.GetListOfKeys():
         obj = key.ReadObj()
         if obj.IsA().InheritsFrom("TH1"):
             name = obj.GetName()
-            if 'DM' in name: sign.append( name )
+            i = 0
+            if 'DM' in name:
+                sign.append( name )
+                i = i +1
+            if i > 0 : break
             elif not "data_obs" in name and not "BkgSum" in name: back.append(name)
         # Categories (directories)
         if obj.IsFolder():

--- a/DM/Analysis/datacard.py
+++ b/DM/Analysis/datacard.py
@@ -198,6 +198,10 @@ def datacard(cat, sign):
                 p= p.replace("_ZR","")
             elif ("ZR" in cat and "NuNu" in m): continue
             elif ("ZR" in p): continue
+
+            if "bin" in cat:
+                p = p + cat[cat.find("bin")+3:]
+
             card += "%-25s%-20s%-20s\t%-20s          1.   [0.5,1.5]\n" % (p, 'rateParam', cat, m, )
 
         

--- a/DM/Analysis/datacard.py
+++ b/DM/Analysis/datacard.py
@@ -61,6 +61,7 @@ freenorm = {
 rateparam = {
     'rateTopAH' : 'TTbarSL',
     'rateZjetsAH' : 'DYJetsToNuNu_HT',
+    'rateZjetsAH_ZR' : 'DYJetsToLL_HT', #will effectively be called rateZjetsAH
     'rateWjetsAH' : 'WJetsToLNu_HT',
     'rateTopSL' : 'TTbarSL',
     'rateWjetsSL' : 'WJetsToLNu_HT',
@@ -191,8 +192,16 @@ def datacard(cat, sign):
 
     if verbose: print "  Rate params..."
     for p, m in rateparam.iteritems():
-        if ('AH' in cat and 'AH' in p) or ('SL' in cat and 'SL' in p):
+        print p, m, cat
+        if (('AH' in cat and 'AH' in p) or ('SL' in cat and 'SL' in p)):
+            if ("ZR" in cat and "ZR" in p):
+                p= p.replace("_ZR","")
+            elif ("ZR" in cat and "NuNu" in m): continue
+            elif ("ZR" in p): continue
             card += "%-25s%-20s%-20s\t%-20s          1.   [0.5,1.5]\n" % (p, 'rateParam', cat, m, )
+
+        
+
     
     if verbose: print "  MC statistics..."
     # MC statistics

--- a/DM/Analysis/plot.py
+++ b/DM/Analysis/plot.py
@@ -74,8 +74,6 @@ def plot(var, cut, norm=False, nm1=False):
         binName = "bin_"+binLow+"_"+binHigh
         cut = cut[:cut.find("binned")]
     
-    print "??cuts:",cut
-    print "??bins :", binLow, binHigh
     channel = cut
     plotdir = cut
     plotname = var
@@ -547,7 +545,6 @@ def plotLimit(doBinned = False):
                 bins = np.array(variable[var]['bins'] )
             else:
                 binsize = (variable[var]['max']-variable[var]['min'])/variable[var]['nbins']
-                print "!!!!!!",variable[var]['max'], variable[var]['min'], binsize
                 bins = np.arange(variable[var]['min'], variable[var]['max']+binsize, binsize)
                 
             bins = np.append(bins, 10000) #add essentially infinite upper bound for the last bin
@@ -574,7 +571,7 @@ def plotLimit(doBinned = False):
             del jobs[:]
     print "\n\n@ Main jobs have finished, now running uncertainties\n\n"
     
-    doSys = False
+    doSys = True
     
     if not doSys: return
     
@@ -591,7 +588,6 @@ def plotLimit(doBinned = False):
                     bins = np.array(variable[var]['bins'] )
                 else:
                     binsize = (variable[var]['max']-variable[var]['min'])/variable[var]['nbins']
-                    print "!!!!!!",variable[var]['max'], variable[var]['min'], binsize
                     bins = np.arange(variable[var]['min'], variable[var]['max']+binsize, binsize)
                 
                 bins = np.append(bins, 10000) #add essentially infinite upper bound for the last bin

--- a/DM/Analysis/samples.py
+++ b/DM/Analysis/samples.py
@@ -90,7 +90,7 @@ sample = {
         'plot': True,
     },
     'WJetsToLNu_HT' : {
-        'files' : ['WJetsToLNu_HT-70To100', 'WJetsToLNu_HT-100To200', 'WJetsToLNu_HT-200To400', 'WJetsToLNu_HT-400To600', 'WJetsToLNu_HT-600To800', 'WJetsToLNu_HT-800To1200', 'WJetsToLNu_HT-1200To2500', 'WJetsToLNu_HT-2500ToInf', 'WJetsToQQ_HT-600ToInf'],
+        'files' : ['WJetsToLNu_HT-70To100', 'WJetsToLNu_HT-100To200', 'WJetsToLNu_HT-200To400', 'WJetsToLNu_HT-400To600', 'WJetsToLNu_HT-600To800', 'WJetsToLNu_HT-800To1200', 'WJetsToLNu_HT-1200To2500', 'WJetsToLNu_HT-2500ToInf'],
         'fillcolor' : 881,
         'fillstyle' : 1001,
         'linecolor' : 881,

--- a/DM/Analysis/selections.py
+++ b/DM/Analysis/selections.py
@@ -26,7 +26,7 @@ selection = {
     # Semileptonic category
     #SR
     "SL1m0fSR" : "isWtoMN && nElectrons==0 && nMuons==1 && MET_pt>160. && Lepton1_pt>30. && Lepton1_pfIso<0.15 && Lepton1_id==4 && nJets>=2 && nBTagJets==1 && nForwardJets==0 && mT>160 && mT2>200 && MinDPhi12>1.2 && mTb>180",
-    "SL1m1fSR" : "isWtoMN && nElectrons==0 && nMuons==1 && MET_pt>160. && Lepton1_pt>30. && Lepton1_pfIso<0.15 && Lepton1_id==4 && nJets>=2 && nBTagJets==1 && nForwardJets>=1 && mT>160 && mT2>200 && MinDPhi12>1.2 && mTb>>180",
+    "SL1m1fSR" : "isWtoMN && nElectrons==0 && nMuons==1 && MET_pt>160. && Lepton1_pt>30. && Lepton1_pfIso<0.15 && Lepton1_id==4 && nJets>=2 && nBTagJets==1 && nForwardJets>=1 && mT>160 && mT2>200 && MinDPhi12>1.2 && mTb>180",
 
     "SL1e0fSR" : "isWtoEN && nElectrons==1 && nMuons==0 && MET_pt>160. && Lepton1_pt>30. && abs(Lepton1_eta)<2.1 && Lepton1_id==4 && nJets>=2 && nBTagJets==1 && nForwardJets==0 && mT>160 && mT2>200 && MinDPhi12>1.2 && mTb>180",
     "SL1e1fSR" : "isWtoEN && nElectrons==1 && nMuons==0 && MET_pt>160. && Lepton1_pt>30. && abs(Lepton1_eta)<2.1 && Lepton1_id==4 && nJets>=2 && nBTagJets==1 && nForwardJets>=1 && mT>160 && mT2>200 && MinDPhi12>1.2 && mTb>180",


### PR DESCRIPTION
This should leave all other functionality of plot.py unchanged (will add README later)
Limits can be run the following settings (added -m / --mode and -N / --name to the options)
- python plot.py -l -m "shape" -N "Blabla_shape" (shape based fits, also the default)
- python plot.py -l -m "binned" -N "Blabla_binned" (binned fits)
- python datacards.py -N "Blabla_shape" (to read in a specific set of rootfiles for datacards)
